### PR TITLE
fix: update affiliate state correctly when they get deleted

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -365,6 +365,13 @@ func (client *Client) parseReply(logger *zap.Logger, reply watchReply) {
 			continue
 		}
 
+		if reply.resp.Deleted {
+			// affiliate was deleted server-side
+			delete(client.discoveredAffiliates, affiliate.Id)
+
+			continue
+		}
+
 		if len(affiliate.Data) == 0 {
 			// no affiliate data (yet?), skip it
 			continue


### PR DESCRIPTION
This is client-side only fix, server side had no issues.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>