### PR TITLE
fix: cluster with some subscriptions isn't empty

### DIFF
--- a/internal/state/cluster.go
+++ b/internal/state/cluster.go
@@ -159,7 +159,11 @@ func (cluster *Cluster) GarbageCollect(now time.Time) (removedAffiliates int, em
 		}
 	}
 
-	empty = len(cluster.affiliates) == 0
+	cluster.subscriptionsMu.Lock()
+	subscriptions := len(cluster.subscriptions)
+	cluster.subscriptionsMu.Unlock()
+
+	empty = len(cluster.affiliates) == 0 && subscriptions == 0
 
 	return
 }

--- a/internal/state/cluster_test.go
+++ b/internal/state/cluster_test.go
@@ -130,7 +130,7 @@ func TestClusterMutations(t *testing.T) {
 
 	removedAffiliates, empty = cluster.GarbageCollect(now.Add(2 * time.Minute))
 	assert.Equal(t, 1, removedAffiliates)
-	assert.True(t, empty)
+	assert.False(t, empty)
 
 	select {
 	case notification := <-updates:
@@ -145,6 +145,12 @@ func TestClusterMutations(t *testing.T) {
 		assert.NoError(t, err)
 	default:
 	}
+
+	subscription.Close()
+
+	removedAffiliates, empty = cluster.GarbageCollect(now.Add(2 * time.Minute))
+	assert.Equal(t, 0, removedAffiliates)
+	assert.True(t, empty)
 }
 
 func TestClusterSubscriptions(t *testing.T) {


### PR DESCRIPTION
This addresses a pretty race case when cluster GC runs while the cluster
just got created without any affiliates, but with a subscription.

Client first watches cluster state, then adds an affiliate, so there
might be a case when GC runs and sees a fresh cluster without any
affiliates and GCes it.

This also fixes test instability.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>