### PR TITLE
feat: implement landing page for the discovery service

### DIFF
--- a/internal/landing/html/index.html
+++ b/internal/landing/html/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Discovery Service</title>
+    </head>
+    <body>
+        <h1>What is this IP address?</h1>
+
+        <p>This is the Kubernetes cluster Member Discovery Service run by <a href="https://www.siderolabs.com/kubespan/">Sidero Labs</a>.</p>
+
+        <p>
+            If you see traffic to this IP address, it is from Kubernetes nodes in your organization that are using KubeSpan to coordinate secure, encrypted membership of a Kubernetes cluster.
+            This service provides back information needed to establish the secure communication channels.
+        </p>
+
+        <p>
+            All information to and from this service is encrypted, and the service cannot decrypt the data - only the nodes that are part of the same Kubernetes cluster can decrypt it.
+        </p>
+
+        <p>
+            For more information, see <a href="https://www.siderolabs.com/kubespan/">https://www.siderolabs.com/kubespan/</a>.
+        </p>
+
+        <h2>Details</h2>
+
+        <p>
+            Before sending data to the discovery service, Talos will encrypt the affiliate data with AES-GCM encryption and
+            separately encrypt endpoints with AES in ECB mode so that endpoints coming from different sources can be deduplicated server-side.
+        </p>
+
+        <p>
+            Each node submits it's data encrypted plus it submits the endpoints it sees from other peers to the discovery service.
+            The discovery service aggregates the data, deduplicates the endpoints, and sends updates to each connected peer.
+            Each peer receives information back about other affiliates from the discovery service, decrypts it and uses it to drive KubeSpan and cluster discovery.
+        </p>
+
+        <p>
+            Moreover, the discovery service has no peristence.
+            Data is stored in memory only with a TTL set by the clients (i.e. Talos).
+            The cluster ID is used as a key to select the affiliates (so that different clusters see different affiliates).
+        </p>
+
+        <p>
+            To summarize, the discovery service knows the client version, cluster ID, the number of affiliates, some encrypted data for each affiliate, and a list of encrypted endpoints.
+        </p>
+    </body>
+</html>

--- a/internal/landing/landing.go
+++ b/internal/landing/landing.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package landing provides the HTML landing page.
+package landing
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+//go:embed "html/index.html"
+var static embed.FS
+
+// Handler returns static landing page handler.
+func Handler() http.Handler {
+	subfs, err := fs.Sub(static, "html")
+	if err != nil {
+		panic(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.FileServer(http.FS(subfs)))
+
+	return mux
+}


### PR DESCRIPTION
Landing page is served on a different port for easier ingress
configuration.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>