### PR TITLE
feat: improve version parsing

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,7 +46,7 @@ func NewClusterServer(state *state.State, stopCh <-chan struct{}) *ClusterServer
 	}
 
 	// initialize vectors to set correct descriptors
-	srv.mHello.WithLabelValues("unknown")
+	srv.mHello.WithLabelValues(parseVersion(""))
 
 	return srv
 }
@@ -58,10 +58,7 @@ func NewTestClusterServer(logger *zap.Logger) *ClusterServer {
 
 // Hello implements cluster API.
 func (srv *ClusterServer) Hello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloResponse, error) {
-	clientVersion := req.ClientVersion
-	if clientVersion == "" {
-		clientVersion = "unknown"
-	}
+	clientVersion := parseVersion(req.ClientVersion)
 
 	srv.mHello.WithLabelValues(clientVersion).Inc()
 

--- a/pkg/server/version.go
+++ b/pkg/server/version.go
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package server
+
+import (
+	"regexp"
+)
+
+var vRE = regexp.MustCompile(`^(v\d+\.\d+\.\d+\-?[^-]*)(.*)$`)
+
+func parseVersion(v string) string {
+	m := vRE.FindAllStringSubmatch(v, -1)
+
+	if len(m) == 1 && len(m[0]) == 3 {
+		res := m[0][1]
+		if m[0][2] != "" {
+			res += "-dev"
+		}
+
+		return res
+	}
+
+	return "unknown"
+}

--- a/pkg/server/version_test.go
+++ b/pkg/server/version_test.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package server //nolint:testpackage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVersion(t *testing.T) {
+	t.Parallel()
+
+	for v, expected := range map[string]string{
+		"":                                  "unknown",
+		"unknown":                           "unknown",
+		"v0.13.0":                           "v0.13.0",
+		"v0.13.0-beta.0":                    "v0.13.0-beta.0",
+		"v0.14.0-alpha.0-7-gf7d9f211":       "v0.14.0-alpha.0-dev",
+		"v0.14.0-alpha.0-7-gf7d9f211-dirty": "v0.14.0-alpha.0-dev",
+	} {
+		v, expected := v, expected
+
+		t.Run(v, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, expected, parseVersion(v))
+		})
+	}
+}


### PR DESCRIPTION
Do not store versions like `v0.14.0-alpha.0-7-gf7d9f211-dirty` to avoid
a combinatorial explosion in Prometheus.
