### PR TITLE
fix: use shared gRPC buffers, lower buffer size

### DIFF
--- a/cmd/discovery-service/main.go
+++ b/cmd/discovery-service/main.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/experimental"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
@@ -192,6 +193,10 @@ func run(ctx context.Context, logger *zap.Logger) error {
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime: 10 * time.Second,
 		}),
+		grpc.SharedWriteBuffer(true),
+		experimental.RecvBufferPool(grpc.NewSharedBufferPool()),
+		grpc.ReadBufferSize(16 * 1024),
+		grpc.WriteBufferSize(16 * 1024),
 	}
 
 	state := state.NewState(logger)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/experimental"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -98,6 +99,10 @@ func setupServer(t *testing.T, rateLimit rate.Limit, redirectEndpoint string) *t
 			server.AddLoggingFieldsStreamServerInterceptor(),
 			server.RateLimitStreamServerInterceptor(limiter),
 		),
+		grpc.SharedWriteBuffer(true),
+		experimental.RecvBufferPool(grpc.NewSharedBufferPool()),
+		grpc.ReadBufferSize(16 * 1024),
+		grpc.WriteBufferSize(16 * 1024),
 	}
 
 	testServer.s = grpc.NewServer(testServer.serverOptions...)


### PR DESCRIPTION
As Discovery Service handles lots of connections with relatively low traffic on each connection, lower the buffer size and re-use the read/write buffers.