### PR TITLE
feat: add support for x-forwaded-for header

### DIFF
--- a/cmd/discovery-service/main.go
+++ b/cmd/discovery-service/main.go
@@ -24,19 +24,20 @@ import (
 )
 
 var (
-	listenAddr       = ":3000"
-	landingAddr      = ":3001"
-	metricsAddr      = ":2122"
-	debugAddr        = ":2123"
-	devMode          = false
-	gcInterval       = time.Minute
-	redirectEndpoint = ""
-	snapshotsEnabled = true
-	snapshotPath     = "/var/discovery-service/state.binpb"
-	snapshotInterval = 10 * time.Minute
-	certificatePath  = ""
-	keyPath          = ""
-	trustXRealIP     = true
+	listenAddr              = ":3000"
+	landingAddr             = ":3001"
+	metricsAddr             = ":2122"
+	debugAddr               = ":2123"
+	devMode                 = false
+	gcInterval              = time.Minute
+	redirectEndpoint        = ""
+	snapshotsEnabled        = true
+	snapshotPath            = "/var/discovery-service/state.binpb"
+	snapshotInterval        = 10 * time.Minute
+	certificatePath         = ""
+	keyPath                 = ""
+	trustXRealIP            = true
+	trustFirstXForwardedFor = true
 )
 
 func init() {
@@ -52,6 +53,7 @@ func init() {
 	flag.StringVar(&snapshotPath, "snapshot-path", snapshotPath, "path to the snapshot file")
 	flag.DurationVar(&snapshotInterval, "snapshot-interval", snapshotInterval, "interval to save the snapshot")
 	flag.BoolVar(&trustXRealIP, "trust-x-real-ip", trustXRealIP, "trust X-Real-IP header")
+	flag.BoolVar(&trustFirstXForwardedFor, "trust-first-x-forwarded-for", trustFirstXForwardedFor, "trust the first entry in the X-Forwarded-For header")
 
 	if debug.Enabled {
 		flag.StringVar(&debugAddr, "debug-addr", debugAddr, "debug (pprof, trace, expvar) listen addr")
@@ -104,7 +106,8 @@ func main() {
 
 			MetricsRegisterer: prometheus.DefaultRegisterer,
 
-			TrustXRealIP: trustXRealIP,
+			TrustXRealIP:           trustXRealIP,
+			TrustFirstXForwadedFor: trustFirstXForwardedFor,
 		}, logger)
 	}); err != nil {
 		logger.Error("service failed", zap.Error(err))

--- a/pkg/server/addr.go
+++ b/pkg/server/addr.go
@@ -8,16 +8,25 @@ package server
 import (
 	"context"
 	"net/netip"
+	"strings"
 
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 )
 
-var trustXRealIP bool
+var (
+	trustXRealIP            bool
+	trustFirstXForwardedFor bool
+)
 
 // TrustXRealIP enables X-Real-IP header support.
 func TrustXRealIP(enabled bool) {
 	trustXRealIP = enabled
+}
+
+// TrustFirstXForwardedFor enables X-Forwarded-For header support.
+func TrustFirstXForwardedFor(enabled bool) {
+	trustFirstXForwardedFor = enabled
 }
 
 // PeerAddress is used to extract peer address from the client.
@@ -27,8 +36,20 @@ func TrustXRealIP(enabled bool) {
 func PeerAddress(ctx context.Context) netip.Addr {
 	if trustXRealIP {
 		if md, ok := metadata.FromIncomingContext(ctx); ok {
-			if vals := md.Get("X-Real-IP"); vals != nil {
+			if vals := md.Get("X-Real-IP"); len(vals) > 0 {
 				if ip, err := netip.ParseAddr(vals[0]); err == nil {
+					return ip
+				}
+			}
+		}
+	}
+
+	if trustFirstXForwardedFor {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get("X-Forwarded-For"); len(vals) > 0 {
+				first, _, _ := strings.Cut(vals[0], ",")
+
+				if ip, err := netip.ParseAddr(strings.TrimSpace(first)); err == nil {
 					return ip
 				}
 			}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -253,6 +253,23 @@ func TestServerAPI(t *testing.T) {
 		assert.Equal(t, []byte{0x1, 0x2, 0x3, 0x4}, resp.ClientIp)
 	})
 
+	t.Run("HelloWithForwardedFor", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		ctx = metadata.AppendToOutgoingContext(ctx, "X-Forwarded-For", "5.6.7.8,192.168.0.0.1") // with forwarded for IP of client
+
+		resp, err := client.Hello(ctx, &pb.HelloRequest{
+			ClusterId:     "fake",
+			ClientVersion: "v0.12.0",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, []byte{0x5, 0x6, 0x7, 0x8}, resp.ClientIp)
+	})
+
 	t.Run("AffiliateUpdate", func(t *testing.T) {
 		t.Parallel()
 
@@ -628,14 +645,14 @@ func TestValidation(t *testing.T) {
 	})
 }
 
-func testHitRateLimit(client pb.ClusterClient, ip string) func(t *testing.T) {
+func testHitRateLimit(client pb.ClusterClient, ip string, headerName string) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer cancel()
 
-		ctx = metadata.AppendToOutgoingContext(ctx, "X-Real-IP", ip)
+		ctx = metadata.AppendToOutgoingContext(ctx, headerName, ip)
 
 		for range limits.IPRateBurstSizeMax {
 			_, err := client.Hello(ctx, &pb.HelloRequest{
@@ -664,8 +681,8 @@ func TestServerRateLimit(t *testing.T) {
 
 	client := pb.NewClusterClient(conn)
 
-	t.Run("HitRateLimitIP1", testHitRateLimit(client, "1.2.3.4"))
-	t.Run("HitRateLimitIP2", testHitRateLimit(client, "5.6.7.8"))
+	t.Run("HitRateLimitIP1", testHitRateLimit(client, "1.2.3.4", "X-Real-IP"))
+	t.Run("HitRateLimitIP2", testHitRateLimit(client, "5.6.7.8", "X-Forwarded-For"))
 }
 
 func TestServerRedirect(t *testing.T) {
@@ -737,4 +754,5 @@ func BenchmarkViaClient(b *testing.B) {
 
 func init() {
 	server.TrustXRealIP(true)
+	server.TrustFirstXForwardedFor(true)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -70,6 +70,7 @@ type Options struct {
 	MetricsServerEnabled     bool
 	SnapshotsEnabled         bool
 	TrustXRealIP             bool
+	TrustFirstXForwadedFor   bool
 	DisableClientIPReporting bool
 }
 
@@ -125,6 +126,7 @@ func Run(ctx context.Context, options Options, logger *zap.Logger) error {
 	defer logger.Info("service shut down")
 
 	server.TrustXRealIP(options.TrustXRealIP)
+	server.TrustFirstXForwardedFor(options.TrustFirstXForwadedFor)
 
 	state := state.NewState(logger)
 


### PR DESCRIPTION
Adds support for using the first entry of the X-Forwaded-For header as the client IP, to support reverse proxies other than nginx.