### PR TITLE
feat(stats): add cached /stats endpoint

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -135,6 +135,18 @@ func (state *State) RunGC(ctx context.Context, logger *zap.Logger, interval time
 	}
 }
 
+// Stats is a snapshot of the current state counters.
+type Stats struct {
+	Affiliates int `json:"affiliates"`
+}
+
+// Stats returns a snapshot of the current state counters.
+func (state *State) Stats() Stats {
+	_, a, _, _ := state.stats() //nolint:dogsled // We only need affiliates count for now.
+
+	return Stats{Affiliates: a}
+}
+
 func (state *State) stats() (clusters, affiliates, endpoints, subscriptions int) {
 	for _, cluster := range state.clusters.All() {
 		clusters++

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package stats provides a cache for the state counters, which are expensive to compute.
+package stats
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/siderolabs/discovery-service/internal/state"
+)
+
+func Handler(state *state.State, logger *zap.Logger) http.Handler {
+	mux := http.NewServeMux()
+
+	statsHandler := &statsCache{state: state, ttl: time.Hour}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if err := statsHandler.StatsHandler(w, r); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.WriteHeader(http.StatusInternalServerError)
+			io.WriteString(w, `{"error": "Oops, try again"}`) //nolint:errcheck
+			logger.Error("failed to return stats", zap.Error(err))
+		}
+	})
+
+	return mux
+}
+
+type statsSnapshot struct {
+	expiry time.Time
+	data   []byte
+}
+
+// statsCache serves the state counters as JSON, recomputing at most once per TTL.
+//
+// stats() is an O(n) scan, so concurrent misses are collapsed into a single
+// recompute via singleflight. The snapshot is swapped atomically, so reads are
+// lock-free.
+type statsCache struct {
+	state *state.State
+	cur   atomic.Pointer[statsSnapshot]
+	group singleflight.Group
+	ttl   time.Duration
+}
+
+func (c *statsCache) StatsHandler(w http.ResponseWriter, _ *http.Request) error {
+	snap := c.cur.Load()
+
+	if snap == nil || time.Now().After(snap.expiry) {
+		v, err, _ := c.group.Do("stats", func() (any, error) {
+			b, err := json.Marshal(c.state.Stats())
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal stats: %w", err)
+			}
+
+			s := &statsSnapshot{data: b, expiry: time.Now().Add(c.ttl)}
+			c.cur.Store(s)
+
+			return s, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		var ok bool
+
+		snap, ok = v.(*statsSnapshot)
+		if !ok {
+			return fmt.Errorf("unexpected type %T", v)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Write(snap.data) //nolint:errcheck
+
+	return nil
+}

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package stats //nolint:testpackage // exercises unexported statsCache
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/discovery-service/internal/state"
+)
+
+func TestStatsCache(t *testing.T) {
+	st := state.NewState(zaptest.NewLogger(t))
+
+	require.NoError(t, st.GetCluster("c1").WithAffiliate("a1", func(a *state.Affiliate) error {
+		a.Update([]byte("d"), time.Now().Add(time.Hour))
+
+		return nil
+	}))
+
+	get := func(c *statsCache) state.Stats {
+		rec := httptest.NewRecorder()
+		require.NoError(t, c.StatsHandler(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil)))
+		require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+		var s state.Stats
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &s))
+
+		return s
+	}
+
+	// long TTL: second mutation must not be visible (served from cache).
+	cached := &statsCache{state: st, ttl: time.Hour}
+	require.Equal(t, 1, get(cached).Affiliates)
+
+	require.NoError(t, st.GetCluster("c1").WithAffiliate("a2", func(a *state.Affiliate) error {
+		a.Update([]byte("d"), time.Now().Add(time.Hour))
+
+		return nil
+	}))
+
+	require.Equal(t, 1, get(cached).Affiliates, "stale value should be served within TTL")
+
+	// zero TTL: always recomputed.
+	uncached := &statsCache{state: st, ttl: 0}
+	require.Equal(t, 2, get(uncached).Affiliates)
+
+	require.NoError(t, st.GetCluster("c1").WithAffiliate("a3", func(a *state.Affiliate) error {
+		a.Update([]byte("d"), time.Now().Add(time.Hour))
+
+		return nil
+	}))
+
+	require.Equal(t, 3, get(uncached).Affiliates)
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -36,6 +36,7 @@ import (
 	"github.com/siderolabs/discovery-service/internal/limiter"
 	"github.com/siderolabs/discovery-service/internal/state"
 	storageinternal "github.com/siderolabs/discovery-service/internal/state/storage"
+	"github.com/siderolabs/discovery-service/internal/stats"
 	"github.com/siderolabs/discovery-service/pkg/limits"
 	"github.com/siderolabs/discovery-service/pkg/server"
 	"github.com/siderolabs/discovery-service/pkg/storage"
@@ -150,7 +151,9 @@ func Run(ctx context.Context, options Options, logger *zap.Logger) error {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 
-	landingHandler := landing.Handler(state, logger)
+	siteMux := http.NewServeMux()
+	siteMux.Handle("/stats", stats.Handler(state, logger))
+	siteMux.Handle("/", landing.Handler(state, logger))
 
 	eg, ctx := errgroup.WithContext(ctx)
 
@@ -158,7 +161,7 @@ func Run(ctx context.Context, options Options, logger *zap.Logger) error {
 		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
 			s.ServeHTTP(w, r)
 		} else {
-			landingHandler.ServeHTTP(w, r)
+			siteMux.ServeHTTP(w, r)
 		}
 	})
 
@@ -232,7 +235,7 @@ func Run(ctx context.Context, options Options, logger *zap.Logger) error {
 		}
 
 		landingServer := http.Server{
-			Handler: landingHandler,
+			Handler: siteMux,
 		}
 
 		eg.Go(func() error {


### PR DESCRIPTION
Serve active instance (affiliate) count as JSON on the main and
landing servers, similar to https://analytics.pocket-id.org/stats.
Counting scans all clusters, so results are cached for 1h and
concurrent recomputes collapse via singleflight.

Lets the Talos website showcase how many Talos users run against the
public discovery instances.

<details><summary>Screenshots</summary>
<img width="1235" height="708" alt="Screenshot 2026-07-21 at 13 33 58" src="https://github.com/user-attachments/assets/9d873594-aaf6-48ee-a469-b9ee5138ac09" />
<img width="440" height="741" alt="Screenshot 2026-07-21 at 13 33 37" src="https://github.com/user-attachments/assets/9f8731a1-45b7-4c34-9d47-0d60aecbc1d1" />
</details>


Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
